### PR TITLE
Bump scala version to minimum compatible with java 21

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -213,8 +213,8 @@ dependencies {
   client group: 'org.battlecode', name: clientName + clientType, version: versions.battlecodeClient
 
   // Scala
-  implementation group: 'org.scala-lang', name: 'scala-library', version: '2.11.7'
-  testImplementation group: 'org.scalatest', name: 'scalatest_2.11', version: '3.0.0'
+  implementation group: 'org.scala-lang', name: 'scala-library', version: '2.13.11'
+  testImplementation group: 'org.scalatest', name: 'scalatest_2.13', version: '3.2.9'
 }
 
 


### PR DESCRIPTION
Java 21 and Scala 2.11 do not mix. This PR bumps the Scala 2 version to 2.13 so that those programs continue to compile in future tournaments.